### PR TITLE
Fixed the violation of nodes ordering

### DIFF
--- a/cdt/causality/graph/GES.py
+++ b/cdt/causality/graph/GES.py
@@ -137,13 +137,13 @@ class GES(GraphModel):
         self.arguments['{VERBOSE}'] = str(self.verbose).upper()
         self.arguments['{SCORE}'] = self.scores[self.score]
 
-        fe = DataFrame(nx.adj_matrix(graph, weight=None).todense())
+        fe = DataFrame(nx.adjacency_matrix(graph, nodelist=sorted(graph.nodes()), weight=None).todense())
         fg = DataFrame(1 - fe.values)
 
         results = self._run_ges(data, fixedGaps=fg, verbose=self.verbose)
 
         return nx.relabel_nodes(nx.DiGraph(results),
-                                {idx: i for idx, i in enumerate(data.columns)})
+                                {idx: i for idx, i in enumerate(sorted(data.columns))})
 
     def orient_directed_graph(self, data, graph):
         """Run GES on a directed graph.

--- a/cdt/causality/graph/GIES.py
+++ b/cdt/causality/graph/GIES.py
@@ -135,13 +135,13 @@ class GIES(GraphModel):
         self.arguments['{VERBOSE}'] = str(self.verbose).upper()
         self.arguments['{SCORE}'] = self.scores[self.score]
 
-        fe = DataFrame(nx.adj_matrix(graph, weight=None).todense())
+        fe = DataFrame(nx.adjacency_matrix(graph, nodelist=sorted(graph.nodes()), weight=None).todense())
         fg = DataFrame(1 - fe.values)
 
         results = self._run_gies(data, fixedGaps=fg, verbose=self.verbose)
 
         return nx.relabel_nodes(nx.DiGraph(results),
-                                {idx: i for idx, i in enumerate(data.columns)})
+                                {idx: i for idx, i in enumerate(sorted(data.columns))})
 
     def orient_directed_graph(self, data, graph):
         """Run GIES on a directed_graph.

--- a/cdt/causality/graph/PC.py
+++ b/cdt/causality/graph/PC.py
@@ -232,13 +232,13 @@ class PC(GraphModel):
         self.arguments['{NJOBS}'] = str(self.njobs)
         self.arguments['{VERBOSE}'] = str(self.verbose).upper()
 
-        fe = DataFrame(nx.adj_matrix(graph, weight=None).todense())
+        fe = DataFrame(nx.adjacency_matrix(graph, nodelist=sorted(graph.nodes()), weight=None).todense())
         fg = DataFrame(1 - fe.values)
 
         results = self._run_pc(data, fixedEdges=fe, fixedGaps=fg, verbose=self.verbose)
 
         return nx.relabel_nodes(nx.DiGraph(results),
-                                {idx: i for idx, i in enumerate(data.columns)})
+                                {idx: i for idx, i in enumerate(sorted(data.columns))})
 
     def orient_directed_graph(self, data, graph, *args, **kwargs):
         """Run PC on a directed_graph (Only takes account of the skeleton of

--- a/cdt/causality/graph/SAMv1.py
+++ b/cdt/causality/graph/SAMv1.py
@@ -210,7 +210,7 @@ def run_SAM(df_data, skeleton=None, device=None, **kwargs):
     # Get the list of indexes to ignore
     if skeleton is not None:
         zero_components = [[] for i in range(cols)]
-        skel = nx.adj_matrix(skeleton, weight=None)
+        skel = nx.adjacency_matrix(skeleton, weight=None, nodelist=sorted(skeleton.nodes()))
         for i, j in zip(*((1-skel).nonzero())):
             zero_components[j].append(i)
     else:
@@ -427,7 +427,7 @@ class SAMv1(GraphModel):
             W /= self.nruns
         return nx.relabel_nodes(nx.DiGraph(W),
                                 {idx: i for idx,
-                                 i in enumerate(data.columns)})
+                                 i in enumerate(sorted(data.columns))})
 
     def orient_directed_graph(self, *args, **kwargs):
         """Orient a (partially directed) graph."""


### PR DESCRIPTION
Fixed the violation of nodes ordering caused by nx.adj_matrix and nx.relabel_nodes.
Bug: The ordering of data(.csv format) columns is not always consistent with the ordering of nodes in nx.graph, thus causing an erroneous mapping. Sorting both lists before calling nx.adj_matrix and nx.relabel_nodes fixes the problem.
Also, nx.adj_matrix is deprecated and is replaced by nx.adjacency_matrix.