### PR TITLE
[FIX] Add `torch` as dependency in `setup.py`.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -22,7 +22,7 @@ def setup_package():
           url='https://github.com/FenTechSolutions/CausalDiscoveryToolbox',
           package_data={'': ['**/*.R', '**/*.csv']},
           install_requires=['numpy', 'scipy', 'scikit-learn',
-                            'joblib', 'pandas', 'statsmodels',
+                            'joblib', 'pandas', 'statsmodels', 'torch',
                             'networkx', 'skrebate', 'tqdm', 'GPUtil', 'requests'],
           include_package_data=True,
           author='Diviyan Kalainathan',


### PR DESCRIPTION
Just a quick fix since I'm having problems using the package without `torch`. One could imagine reading the `requirements.txt` from `setup.py` automatically to avoid these synchronization issues, or migrating to e.g. `poetry`.