### PR TITLE
ANM incompatible with scikit-learn >= 1.1.3

### DIFF
--- a/cdt/causality/pairwise/ANM.py
+++ b/cdt/causality/pairwise/ANM.py
@@ -186,7 +186,7 @@ class ANM(PairwiseModel):
             float: ANM fit score
         """
         gp = GaussianProcessRegressor().fit(x, y)
-        y_predict = gp.predict(x)
+        y_predict = gp.predict(x).reshape(-1, 1)
         indepscore = normalized_hsic(y_predict - y, x)
 
         return indepscore


### PR DESCRIPTION
Pull 22199 into scikit-learn ([https://github.com/https://github.com/scikit-learn/scikit-learn/pull/22199]) changed the shape of the array returned by GaussianProcessRegressor which in turn introduced a bug causing ANM.cause_or_effect to return incorrect results. This pull requests reshapes the returned array using .reshape(-1, 1).